### PR TITLE
[suspendplugin] remove NL80211_WOWLAN_TRIG_ANY. JB#44903

### DIFF
--- a/src/suspendplugin.c
+++ b/src/suspendplugin.c
@@ -209,7 +209,6 @@ suspend_set_wowlan(
 
     wowlan_triggers = nla_nest_start(msg, NL80211_ATTR_WOWLAN_TRIGGERS);
 
-    nla_put_flag(msg, NL80211_WOWLAN_TRIG_ANY);
     nla_put_flag(msg, NL80211_WOWLAN_TRIG_DISCONNECT);
 
     nla_nest_end(msg, wowlan_triggers);


### PR DESCRIPTION
NL80211_WOWLAN_TRIG_ANY means wake up on any event. Currently the
driver seems to only support NL80211_WOWLAN_TRIG_DISCONNECT but
the kernel refuses to accept NL80211_WOWLAN_TRIG_ANY and
NL80211_WOWLAN_TRIG_DISCONNECT at the same time since
NL80211_WOWLAN_TRIG_ANY is less restrictive than specifying the
individual NL80211_WOWLAN_TRIG_* flags.